### PR TITLE
Harmonize Renovate onto shared config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,6 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
-  ],
-  "baseBranch": "rutebanken",
-  "packageRules": [
-    {
-      "matchPackageNames": [
-        "google/cloud-sdk"
-      ],
-      "automerge": true,
-      "separateMinorPatch": false
-    }
+    "github>entur/ror-renovate-config"
   ]
 }


### PR DESCRIPTION
## Harmonize onto the shared Renovate config

Replaces `config:base` with the team's shared preset
`github>entur/ror-renovate-config`.

Dropped local rules that the shared config already covers:
- The `google/cloud-sdk` automerge rule — the shared config already automerges
  `google/cloud-sdk` (it doesn't follow semver).

The `baseBranch: rutebanken` override is removed because `rutebanken` is this
repo's **default branch**; Renovate now targets it automatically (relies on
entur/ror-renovate-config#12, which stops the shared preset forcing `master`).



---
_Part of the team-wide Renovate harmonization. Depends on the shared-config update **entur/ror-renovate-config#12** (merge that first)._