### PR TITLE
ci: skip image build for docs-only changes

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - rutebanken
+    # Skip the image build+push for documentation-only changes. The image is built
+    # from the Dockerfile + profiles/, so markdown changes can never affect it, and
+    # every other path (incl. helm/ values changes like osrmVersion) still triggers.
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches:
       - rutebanken


### PR DESCRIPTION
`push.yml` (Build and push) triggers on every push to `rutebanken` with no path filter, so a docs-only commit — e.g. the OSRM upgrade runbook — builds and deploys a new image. That's how a README commit today kicked off an unwanted build mid-cutover.

### Change
Add `paths-ignore: ['**.md']` to the **push** trigger. A commit whose changes are *all* markdown skips the build; any commit that also touches code, `Dockerfile`, `profiles/**`, or `helm/**` still builds+deploys exactly as before.

### Why this is safe
- The image is built solely from the `Dockerfile` + `profiles/` (`COPY profiles/. /opt/`), so markdown files never affect image contents.
- Only the **push** trigger is filtered; `pull_request` is untouched, so PR checks behave as before.
- **helm-only changes are intentionally *not* ignored** — e.g. the `data.osrmVersion` bump must still build+deploy.