### PR TITLE
Prep for tst/prd v26 rollout (build-then-flip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,46 @@ Recommended procedure, rolled out one environment at a time (dev → tst → prd
 5. Rollback: revert the image and `data.osrmVersion` to the previous prefix and redeploy —
    the old graph data is still there.
 
+#### Environments still on the pre-rename ("water") chart
+
+The deploy-then-rebuild flow above is only safe when the environment is already on the
+current chart, where the `osrm-water` Service selects `app: osrm-ferry` and the ferry
+Deployment exists (dev). An environment still on the **pre-rename chart** (at time of
+writing, **tst and prd**) has `osrm-water` as a *Deployment* (`app: osrm-water`) and the
+`osrm-water` Service selects `app: osrm-water` — there is no `osrm-ferry`. Deploying the
+current chart there does the **water→ferry rename and the v26 bump in one step**, which
+changes the risk:
+
+- **bus / rail** — name unchanged, so old pods keep serving while new ones crashloop on the
+  empty prefix. No outage (same as above).
+- **ferry / water** — the deploy repoints the `osrm-water` Service from `app: osrm-water` to
+  `app: osrm-ferry`. The old pods stop receiving traffic immediately and the new ferry pods
+  aren't ready yet, so **`osrm-water.<env>.entur.internal` goes down** until ferry is healthy.
+  With crashloop-then-rebuild that outage lasts the whole ~30-min rebuild.
+
+So for these environments use **build-then-flip** instead — pre-populate the new prefix
+*before* deploying, so the new pods (including ferry) come up healthy immediately:
+
+1. Pre-build the graph into the new prefix without touching the live deployments, using the
+   **exact image you are about to deploy**:
+
+   ```bash
+   ./prebuild-osrm-graph.sh tst v26 <osrm-api-image-tag>
+   ```
+
+   This runs download → extract → contract → upload for bus, rail and water into
+   `gs://ror-osrm-internal-<env>/v26/…`, with no redeploy — the running v6 pods are
+   unaffected. Wait for all three Jobs to complete and verify the data landed.
+2. Deploy the current chart (v26 image + `osrmVersion=v26` + the rename). Every new pod finds
+   its data already present, so bus/rail converge with no outage and ferry/water has only a
+   brief (~1–2 min) readiness gap when the Service flips, not a 30-min one.
+3. Verify routing on all hosts, then **delete the now-orphaned `osrm-water` Deployment**.
+
+**Before deleting `osrm-water` in any environment, check the Service selector:**
+`kubectl -n osrm get svc osrm-water -o jsonpath='{.spec.selector}'`.
+`app: osrm-ferry` ⇒ the Deployment is an un-pruned orphan, safe to delete. `app: osrm-water`
+⇒ it is still the **live backend** (pre-rename chart) — deleting it takes ferry/water down.
+
 ## Running locally
 
 You can modify profile code locally and test it as follows:

--- a/prebuild-osrm-graph.sh
+++ b/prebuild-osrm-graph.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Pre-build the OSRM graph into a NEW GCS prefix WITHOUT touching the live
+# deployments. Use this before deploying a new osrm-backend major (a "build-then-flip"
+# cutover) so the new pods find their data immediately.
+#
+# Why this exists: an OSRM major bump changes the version-locked graph format AND (for
+# tst/prd) performs the water->ferry rename in the same deploy. If the new pods start
+# on an empty prefix they CrashLoopBackOff; for the renamed ferry/water Service that is
+# an actual outage (the Service flips to the not-yet-ready ferry pods). Pre-populating
+# the new prefix first avoids that: the new pods come up healthy on data that already
+# exists. See the "Upgrading the OSRM version" runbook in README.md.
+#
+# It runs, per profile, the same pipeline as the redeploy CronJob's init containers
+# (download OSM -> osrm-extract -> osrm-contract -> gsutil upload) but with NO redeploy
+# step, so the running (old) deployments keep serving untouched while this builds.
+#
+# Usage:
+#   ./prebuild-osrm-graph.sh <dev|tst|prd> <prefix> <image-tag>
+#
+# Example (prepare tst for v26 with the exact image you're about to deploy):
+#   ./prebuild-osrm-graph.sh tst v26 rutebanken.20260731-SHA6b34719
+#
+# IMPORTANT: <image-tag> MUST be the same osrm-api image you will deploy. The graph
+# format is version-locked, so pre-building with one v26 build and deploying a different
+# major/incompatible build would still crashloop. Pin the deploy to this image, or run
+# this immediately before the deploy with the current image.
+#
+set -euo pipefail
+
+ENV="${1:?usage: $0 <dev|tst|prd> <prefix> <image-tag>}"
+PREFIX="${2:?usage: $0 <dev|tst|prd> <prefix> <image-tag>   (e.g. v26)}"
+IMAGE_TAG="${3:?usage: $0 <dev|tst|prd> <prefix> <image-tag>   (e.g. rutebanken.20260731-SHA6b34719)}"
+
+IMAGE="eu.gcr.io/entur-system-1287/osrm-api:${IMAGE_TAG}"
+OSM_URL="https://storage.googleapis.com/ror-osmdata-prd/osm-data/merged-latest.osm.pbf"
+
+case "$ENV" in
+  dev) CTX=gke_ent-kub-dev_europe-west1_kub-ent-dev-001; BUCKET=ror-osrm-internal-dev ;;
+  tst) CTX=gke_ent-kub-tst_europe-west1_kub-ent-tst-001; BUCKET=ror-osrm-internal-tst ;;
+  prd) CTX=gke_ent-kub-prd_europe-west1_kub-ent-prd-001; BUCKET=ror-osrm-internal-prd ;;
+  *) echo "unknown env: $ENV (expected dev|tst|prd)" >&2; exit 1 ;;
+esac
+
+# profile-lua : service-name (upload path suffix). ferry data is served under "water".
+PROFILES=( "bus:bus" "rail:rail" "ferry:water" )
+
+echo "Pre-building osrm graph  env=$ENV  prefix=$PREFIX  image=$IMAGE"
+echo "  context = $CTX"
+echo "  bucket  = gs://$BUCKET/$PREFIX/"
+echo
+
+for entry in "${PROFILES[@]}"; do
+  PROFILE="${entry%%:*}"; SVC="${entry##*:}"
+  JOB="osrm-${SVC}-prebuild-${PREFIX}"
+  echo ">>> $PROFILE -> gs://${BUCKET}/${PREFIX}/osrm-${SVC}/   (job: $JOB)"
+  kubectl --context "$CTX" -n osrm delete job "$JOB" --ignore-not-found >/dev/null 2>&1 || true
+  cat <<YAML | kubectl --context "$CTX" -n osrm apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: osrm
+  labels:
+    app: osrm-prebuild
+    team: ror
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app: osrm-prebuild
+    spec:
+      restartPolicy: Never
+      serviceAccountName: application
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      volumes:
+        - name: osm-data
+          emptyDir:
+            sizeLimit: 10Gi
+      initContainers:
+        - name: download-osm-data
+          image: curlimages/curl:8.12.1
+          command: ['sh', '-c', 'curl -fSL -o /data/norway-latest.osm.pbf ${OSM_URL}']
+          volumeMounts: [{ mountPath: /data, name: osm-data }]
+          securityContext: { allowPrivilegeEscalation: false, capabilities: { drop: [ALL] }, runAsNonRoot: true, seccompProfile: { type: RuntimeDefault } }
+        - name: osrm-extract
+          image: ${IMAGE}
+          command: ['osrm-extract', '-p', '/opt/${PROFILE}.lua', '/data/norway-latest.osm.pbf']
+          resources:
+            limits: { memory: 16000Mi }
+            requests: { cpu: 6, memory: 14000Mi }
+          volumeMounts: [{ mountPath: /data, name: osm-data }]
+          securityContext: { allowPrivilegeEscalation: false, capabilities: { drop: [ALL] }, runAsNonRoot: true, seccompProfile: { type: RuntimeDefault } }
+        - name: osrm-contract
+          image: ${IMAGE}
+          command: ['osrm-contract', '/data/norway-latest.osrm']
+          resources:
+            limits: { memory: 16000Mi }
+            requests: { cpu: 6, memory: 14000Mi }
+          volumeMounts: [{ mountPath: /data, name: osm-data }]
+          securityContext: { allowPrivilegeEscalation: false, capabilities: { drop: [ALL] }, runAsNonRoot: true, seccompProfile: { type: RuntimeDefault } }
+        - name: upload-osrm-data
+          image: google/cloud-sdk:537.0.0
+          command:
+            - sh
+            - -c
+            - 'gsutil -o GSUtil:parallel_composite_upload_threshold=150M -q -m rsync -d -r -x "^(?!.*norway-latest.osrm\.).*" /data gs://${BUCKET}/${PREFIX}/osrm-${SVC}/'
+          env: [{ name: CLOUDSDK_CORE_DISABLE_PROMPTS, value: "1" }]
+          volumeMounts: [{ mountPath: /data, name: osm-data }]
+          securityContext: { allowPrivilegeEscalation: false, capabilities: { drop: [ALL] }, runAsNonRoot: true, seccompProfile: { type: RuntimeDefault } }
+      containers:
+        - name: done
+          image: google/cloud-sdk:537.0.0
+          command: ['sh', '-c', 'echo "prebuild complete: gs://${BUCKET}/${PREFIX}/osrm-${SVC}/"']
+          securityContext: { allowPrivilegeEscalation: false, capabilities: { drop: [ALL] }, runAsNonRoot: true, seccompProfile: { type: RuntimeDefault } }
+YAML
+done
+
+echo
+echo "Jobs created. Watch progress:"
+echo "  kubectl --context $CTX -n osrm get jobs -l app=osrm-prebuild -w"
+echo
+echo "When all show Complete, verify the data landed:"
+for entry in "${PROFILES[@]}"; do SVC="${entry##*:}"
+  echo "  gsutil ls gs://${BUCKET}/${PREFIX}/osrm-${SVC}/ | head"
+done
+echo
+echo "Only after all three prefixes are populated, deploy the ${IMAGE_TAG} chart"
+echo "(osrmVersion=${PREFIX}) to $ENV."


### PR DESCRIPTION
Prepares the tst/prd v26 rollout, which is trickier than dev because those envs are still on the **pre-rename chart** — they run `osrm-water` as a Deployment (`app: osrm-water`), the `osrm-water` Service selects `app: osrm-water`, and there is no `osrm-ferry`. Deploying the current chart there performs the **water→ferry rename and the v26 bump in one step**.

### The risk
- bus/rail: name unchanged → old pods serve while new ones crashloop on the empty `/v26` → no outage.
- **ferry/water: the deploy repoints the `osrm-water` Service to `app: osrm-ferry`** → old pods drop out, new ferry pods aren't ready → `osrm-water.<env>.entur.internal` is **down** until ferry is healthy. Under crashloop-then-rebuild that's a ~30-min outage.

So tst/prd need **build-then-flip**, not the dev-style crashloop-then-rebuild.

### Changes
- **`prebuild-osrm-graph.sh`** — builds the graph into a new prefix (`/v26`) for bus/rail/water using one-off Jobs on the exact image you're about to deploy, with **no redeploy step**, so the live v6 deployments are untouched while it builds. `./prebuild-osrm-graph.sh <dev|tst|prd> <prefix> <image-tag>`.
- **README runbook** — a new "Environments still on the pre-rename chart" section: build-then-flip steps, and the rule to **check the `osrm-water` Service selector before deleting the Deployment** (`app: osrm-ferry` ⇒ orphan, safe; `app: osrm-water` ⇒ live backend, do not delete).

Context: this is the follow-through from the dev v26 upgrade (#132/#133) and the tst/prd `osrm-water` incident.

Note: contains a shell script (not markdown), so merging will trigger a build; harmless (image unchanged). #136 adds the docs path-filter but only for `**.md`.